### PR TITLE
Github Action to publish the docker images on Docker Hub

### DIFF
--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -1,0 +1,69 @@
+name: Publish docker images to DockerHub
+
+on:
+    push:
+        branches: ["**"]
+
+jobs:
+    push_api:
+        name: Push API Image to DockerHub
+        runs-on: ubuntu-latest
+        permissions:
+                packages: write
+                contents: read
+                attestations: write
+                id-token: write
+        steps:
+            - name: Check out the repo
+              uses: actions/checkout@v4
+            - name: Log in to Docker Hub
+              uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+              with:
+                username: ${{ secrets.DOCKER_USERNAME }}
+                password: ${{ secrets.DOCKER_PASSWORD }}
+            
+            - name: Extract metadata (tags, labels) for Docker
+              id: meta
+              uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+              with:
+                images: ${{ vars.DOCKER_HUB_NAMESPACE }}/impact-api
+            - name: Build and push Docker image
+              id: push
+              uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+              with:
+                  context: ./api/
+                  file: ./api/Dockerfile
+                  push: true
+                  tags: ${{ steps.meta.outputs.tags }}
+                  labels: ${{ steps.meta.outputs.labels }}
+    push_pwa:
+        name: Push PWA Image to DockerHub
+        runs-on: ubuntu-latest
+        permissions:
+                packages: write
+                contents: read
+                attestations: write
+                id-token: write
+        steps:
+            - name: Check out the repo
+              uses: actions/checkout@v4
+            - name: Log in to Docker Hub
+              uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+              with:
+                username: ${{ secrets.DOCKER_USERNAME }}
+                password: ${{ secrets.DOCKER_PASSWORD }}
+            
+            - name: Extract metadata (tags, labels) for Docker
+              id: meta
+              uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+              with:
+                images: ${{ vars.DOCKER_HUB_NAMESPACE }}/impact-pwa
+            - name: Build and push Docker image
+              id: push
+              uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+              with:
+                  context: ./pwa/
+                  file: ./pwa/Dockerfile
+                  push: true
+                  tags: ${{ steps.meta.outputs.tags }}
+                  labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Github Action to publish the docker images on Docker Hub

This action uploads Impact docker images to Docker Hub.

Requirements :
- Set your Docker Hub username and passwords into the repository secrets (using names : DOCKER_USERNAME and DOCKER_PASSWORD)
- Set the DOCKER_HUB_NAMESPACE env variable that is your public user namespace on github (eg. for me it's thesupergeek)
- Create an image for each project on your docker hub (impact-api and impact-pwa, for reference see this : https://hub.docker.com/r/thesupergeek/impact-pwa)

You also need to change the docker-compose for using the images published to dockerhub.