### PR TITLE
fix(ci): Improve rsync copy in deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Change SSH fingerprint
         run: ssh-keyscan -t rsa ${{ secrets.SSH_HOST }} >> ~/.ssh/known_hosts
       - name: Copy with rsync
-        run: rsync -avz . ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:/home/webapp/impact-api/
+        run: rsync -avz --delete --exclude=".git" --exclude=".idea" --exclude=".github" . ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:/home/webapp/impact-api/
       - name: Restart docker
         run: ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} "cd /home/webapp/impact-api/ && docker compose -f compose.yaml -f compose.prod.yaml build --no-cache && docker compose down && docker compose -f compose.yaml -f compose.prod.yaml --env-file .env up --wait"
       - name: Generate JWT Keys

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,7 @@ jobs:
   deploy:
     name: "Deployment"
     runs-on: ubuntu-latest
+    if: github.repository == 'Lauwed/impact-api'
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@
 
 As the project is still small and the setup isn't finish yet, please create your branch from `main` and submit your Pull Request when you are finished with your developments.
 
+### ⚠️ Warning regarding --delete
+The deployment workflow uses --delete option of `rsync` ensures that files removed from the Git repository are also deleted from the server. However, be cautious if the application generates files in production (e.g., logs, cache, or uploaded files), as they could be unintentionally deleted. If necessary, add specific --exclude rules to protect such directories.
+
 ## Install
 
 ### Docker


### PR DESCRIPTION
## Changes made in the deployment process

- Added `--delete` flag to remove obsolete files from the server that no longer exist in the repository.
- Excluded unnecessary directories from rsync:
   - `.git` → The Git directory is not needed on the server.
   - `.idea` → IDE configuration files should not be deployed.
   - `.github` → GitHub-specific files (such as workflows) are not relevant for deployment.
- Don't run deployment workflow in forks

## ⚠️ Warning regarding --delete
The `--delete` option ensures that files removed from the Git repository are also deleted from the server. However, be cautious if the application generates files in production (e.g., logs, cache, or uploaded files), as they could be unintentionally deleted. If necessary, add specific --exclude rules to protect such directories. 

➡️  A test was performed, and no unintended files were deleted. The deployment remains safe, but future changes should be reviewed to avoid potential issues.

